### PR TITLE
[Redaktionella ändringar] Lade till ändringar som missades efter HTM2 2022

### DIFF
--- a/policy_for_tackverksamhet.tex
+++ b/policy_for_tackverksamhet.tex
@@ -79,6 +79,8 @@ Subventionering av arbetskläder motsvarande 350 kr ges till funktionärer som h
     \item Cafémästare
     \item Vice cafémästare
     \item Dagsansvarig
+    \item Brunchmästare
+    \item Inventarieansvarig
   \end{itemize}
   \subsubsection*{Skattmästeriet}
   \begin{itemize}

--- a/policy_for_val.tex
+++ b/policy_for_val.tex
@@ -113,6 +113,8 @@ post i det berörda valet eller suttit med i den berörda valberedningen.
     \subsubsection*{Cafémästeriet}
     \begin{itemize}
         \item Dagsansvarig
+        \item Brunchmätare
+        \item Inventarieansvarig
     \end{itemize}
 
     \subsubsection*{Näringslivsutskottet}
@@ -181,6 +183,8 @@ post i det berörda valet eller suttit med i den berörda valberedningen.
     \begin{itemize}
         \item Stekare
         \item Funktionär
+        \item Brunchmästare
+        \item Inventarieansvarig
     \end{itemize}
 
     \subsubsection*{Källarmästeriet}


### PR DESCRIPTION
Ändringar som gjordes i appendix A och B i 'Policy för val' samt under punkt 3.3 i 'Policy för tackverksamhet', där de nya posterna - brunchmästare och inventarieansvarig - lades till, missades att uppdateras i GitHub-repot. Denna ändring fixar det. 