### PR TITLE
Ändringar som gjordes under mötet till policy för ekonomi

### DIFF
--- a/policy_for_ekonomi.tex
+++ b/policy_for_ekonomi.tex
@@ -73,6 +73,14 @@ handlingsutrymme utanför rambudget respektive detaljbudgeten.
 Om en budgetpost inom ett kostnadställe, hela kostnadsstället eller rambudgeten
 i sin helhet avsiktligt beräknas avvika negativt kan ett budgetavsteg göras.
 
+Summan av de budgetavsteg som tas mellan två stycken redovisningstillfällen
+(sektions- och styrelsemöten) får totalt inte överstiga gränsen som kräver
+beslut från den högre instansen.  Till exempel så kan inte styrelsen ta två
+budgetavsteg à 20 000 kr på ett och samma kostnadsställe utan att först redovisa
+det första för sektionsmötet innan det andra tas.  På samma sätt kan inte
+skattmästaren ta två budgetavsteg à 1500 kr på samma budgetpost utanatt redovisa
+det första för styrelsen först.
+
 \begin{center}
   \renewcommand{\arraystretch}{1.75}
   \begin{tabular}{p{0.2\textwidth}|p{0.4\textwidth}|p{0.3\textwidth}}
@@ -94,17 +102,11 @@ i sin helhet avsiktligt beräknas avvika negativt kan ett budgetavsteg göras.
 än 10 000 kr även om detta är mer än 50\% av budgeterat resultat.
 
 Budgetavstegen ska vara skriftliga och dokumenteras för verksamhetens ekonomiska
-kontinuitet. När budgetavsteg görs av skattmästaren och sektionsordföranden
-ska dessa redovisas till styrelsen minst en gång i månaden eller oftare om
-skattmästaren anser det vara lämpligt.  Styrelsens och skattmästarens
-budgetavsteg ska redovisas på nästkommande sektionsmöte.
-
-Flera budgetavsteg för samma ekonomiska objekt räknas samman till dess att de
-har redovisats för en högre instans. Till exempel så kan inte styrelsen ta två
-budgetavsteg à 20 000 kr på ett och samma kostnadsställe utan att först redovisa
-det första för sektionsmötet innan det andra tas.  På samma sätt kan inte
-skattmästaren ta två budgetavsteg à 1500 kr på samma budgetpost utanatt redovisa
-det första för styrelsen först.
+kontinuitet. När budgetavsteg görs av skattmästaren och sektionsordföranden ska
+dessa redovisas på ett styrelsemöte eller som ett per capsulambeslut minst en
+gång i månaden eller oftare om skattmästaren anser det vara lämpligt.
+Styrelsens och skattmästarens budgetavsteg ska redovisas på nästkommande
+sektionsmöte.
 
 \section{Avtal}
 Firmatecknare äger alltid rätt att besluta om avtal som innebär ett positivt nettoresultat och om


### PR DESCRIPTION
Hej igen. Jag kom att tänka på att vi gjorde ändringar under mötet till propositionen för policy för ekonomi, vilket jag inte tog hänsyn till när jag gjorde min förra PR. Så här är de ändringarna. Sorry för förvirringen.